### PR TITLE
fix decimal filter default value not working

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -3,6 +3,7 @@ package liquid
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,7 +68,14 @@ func NewEngine() *Engine {
 		}
 	})
 
-	engine.RegisterFilter("decimal", func(s int64, format string, currency string) string {
+	engine.RegisterFilter("decimal", func(s string, format string, currency string) string {
+		if s == "" {
+			return s
+		}
+		num, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return s
+		}
 		var formatTemplate string
 		switch format {
 		case "whole":
@@ -80,7 +88,7 @@ func NewEngine() *Engine {
 			formatTemplate = "%.2f"
 		}
 
-		value := fmt.Sprintf(formatTemplate, float64(s)/1000)
+		value := fmt.Sprintf(formatTemplate, float64(num)/1000)
 		if currency != "" {
 			return currency + value
 		}

--- a/engine.go
+++ b/engine.go
@@ -1,12 +1,14 @@
 package liquid
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/autopilot3/ap3-helpers-go/logger"
 	"github.com/autopilot3/ap3-types-go/types/date"
 	"github.com/autopilot3/liquid/filters"
 	"github.com/autopilot3/liquid/render"
@@ -74,6 +76,7 @@ func NewEngine() *Engine {
 		}
 		num, err := strconv.ParseFloat(s, 64)
 		if err != nil {
+			logger.Warnw(context.Background(), fmt.Sprintf("failed to parse field value %s to decimal: %s", s, err.Error()), "lqiuid", "filter")
 			return s
 		}
 		var formatTemplate string

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/autopilot3/ap3-crm-api-go v0.0.0-20210317062639-fb091f77a29a
+	github.com/autopilot3/ap3-helpers-go v0.0.0-20210315005720-2a7e262845bb
 	github.com/autopilot3/ap3-types-go v0.0.0-20210218065039-09caa37222f1
 	github.com/osteele/tuesday v1.0.3
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
https://trello.com/c/i28iIDD5/7142-empty-decimal-field-type-does-not-fallback-to-use-default-values