### PR TITLE
introduce thousand delimiter for decimal by default

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -13,6 +13,9 @@ import (
 	"github.com/autopilot3/liquid/filters"
 	"github.com/autopilot3/liquid/render"
 	"github.com/autopilot3/liquid/tags"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 // An Engine parses template source into renderable text.
@@ -91,7 +94,8 @@ func NewEngine() *Engine {
 			formatTemplate = "%.2f"
 		}
 
-		value := fmt.Sprintf(formatTemplate, float64(num)/1000)
+		p := message.NewPrinter(language.English)
+		value := p.Sprintf(formatTemplate, float64(num)/1000)
 		if currency != "" {
 			return currency + value
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/autopilot3/ap3-types-go v0.0.0-20210218065039-09caa37222f1
 	github.com/osteele/tuesday v1.0.3
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/text v0.3.5
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
https://trello.com/c/rjhs1eeY/9333-decimal-and-currency-fields-are-not-inserted-with-thousand-separating-commas-in-emails