### PR TITLE
override first last filter

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -202,22 +202,41 @@ func NewEngine() *Engine {
 				return ""
 			}
 			return splits[0]
-		case reflect.Slice:
-			slice := s.([]interface{})
-			if len(slice) == 0 {
+		case reflect.Slice,
+			reflect.Array:
+			v := reflect.ValueOf(s)
+			if v.IsNil() {
 				return nil
 			}
-			return slice[0]
+			if v.Len() == 0 {
+				return nil
+			}
+			return v.Index(0)
 		}
 		return nil
 	})
 
-	engine.RegisterFilter("last", func(s string) string {
-		splits := strings.Split(s, ",")
-		if len(splits) == 0 {
-			return ""
+	engine.RegisterFilter("last", func(s interface{}) interface{} {
+		switch k := reflect.TypeOf(s).Kind(); k {
+		case reflect.String:
+			str := s.(string)
+			splits := strings.Split(str, ",")
+			if len(splits) == 0 {
+				return ""
+			}
+			return splits[len(splits)-1]
+		case reflect.Slice,
+			reflect.Array:
+			v := reflect.ValueOf(s)
+			if v.IsNil() {
+				return nil
+			}
+			if v.Len() == 0 {
+				return nil
+			}
+			return v.Index(v.Len() - 1)
 		}
-		return splits[len(splits)-1]
+		return nil
 	})
 
 	return engine

--- a/engine.go
+++ b/engine.go
@@ -194,6 +194,9 @@ func NewEngine() *Engine {
 	})
 
 	engine.RegisterFilter("first", func(s interface{}) interface{} {
+		if s == nil {
+			return nil
+		}
 		switch k := reflect.TypeOf(s).Kind(); k {
 		case reflect.String:
 			str := s.(string)
@@ -217,6 +220,9 @@ func NewEngine() *Engine {
 	})
 
 	engine.RegisterFilter("last", func(s interface{}) interface{} {
+		if s == nil {
+			return nil
+		}
 		switch k := reflect.TypeOf(s).Kind(); k {
 		case reflect.String:
 			str := s.(string)

--- a/engine.go
+++ b/engine.go
@@ -191,6 +191,23 @@ func NewEngine() *Engine {
 		}
 		return true
 	})
+
+	engine.RegisterFilter("first", func(s string) string {
+		splits := strings.Split(s, ",")
+		if len(splits) == 0 {
+			return ""
+		}
+		return splits[0]
+	})
+
+	engine.RegisterFilter("last", func(s string) string {
+		splits := strings.Split(s, ",")
+		if len(splits) == 0 {
+			return ""
+		}
+		return splits[len(splits)-1]
+	})
+
 	return engine
 }
 

--- a/engine.go
+++ b/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -192,12 +193,23 @@ func NewEngine() *Engine {
 		return true
 	})
 
-	engine.RegisterFilter("first", func(s string) string {
-		splits := strings.Split(s, ",")
-		if len(splits) == 0 {
-			return ""
+	engine.RegisterFilter("first", func(s interface{}) interface{} {
+		switch k := reflect.TypeOf(s).Kind(); k {
+		case reflect.String:
+			str := s.(string)
+			splits := strings.Split(str, ",")
+			if len(splits) == 0 {
+				return ""
+			}
+			return splits[0]
+		case reflect.Slice:
+			slice := s.([]interface{})
+			if len(slice) == 0 {
+				return nil
+			}
+			return slice[0]
 		}
-		return splits[0]
+		return nil
 	})
 
 	engine.RegisterFilter("last", func(s string) string {


### PR DESCRIPTION
override the original `first`/`last` filter of array to fit our case

https://trello.com/c/AeUA0yy0/10123-bug-using-first-in-liquid-syntax-on-an-array-will-prevent-emails-from-being-sent?filter=member:sachafroment5