### PR TITLE
add ability to only render allowed merge tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.output
 *.out
 /liquid

--- a/engine.go
+++ b/engine.go
@@ -25,6 +25,11 @@ import (
 // An engine can be configured with additional filters and tags.
 type Engine struct{ cfg render.Config }
 
+func (e *Engine) SetAllowedTags(allowedTags map[string]struct{}) *Engine {
+	e.cfg.AllowedTags = allowedTags
+	return e
+}
+
 // NewEngine returns a new Engine.
 func NewEngine() *Engine {
 	engine := &Engine{render.NewConfig()}
@@ -260,7 +265,6 @@ func (e *Engine) RegisterBlock(name string, td Renderer) {
 // * https://github.com/autopilot3/liquid/blob/master/filters/filters.go
 //
 // * https://github.com/osteele/gojekyll/blob/master/filters/filters.go
-//
 func (e *Engine) RegisterFilter(name string, fn interface{}) {
 	e.cfg.AddFilter(name, fn)
 }

--- a/render/config.go
+++ b/render/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	parser.Config
 	grammar
+	AllowedTags map[string]struct{}
 }
 
 type grammar struct {
@@ -21,5 +22,9 @@ func NewConfig() Config {
 		tags:      map[string]TagCompiler{},
 		blockDefs: map[string]*blockSyntax{},
 	}
-	return Config{parser.NewConfig(g), g}
+	return Config{
+		parser.NewConfig(g),
+		g,
+		nil,
+	}
 }


### PR DESCRIPTION
https://trello.com/c/STb917Mh/11689-template-type-email

In templates screenshot we only want to render a subset liquid tags to show in screenshot so we won't leak any sensitive info