### PR TITLE
add protection and debug log on VariableBind cast error case

### DIFF
--- a/expressions/context.go
+++ b/expressions/context.go
@@ -126,7 +126,11 @@ func (c *varsContext) Get(name string) interface{} {
 				objArrays := strings.SplitN(loopVar.Source, "[]", 2)
 				if len(objArrays) > 1 {
 					if val, ok := c.variables[objArrays[0]]; ok {
-						bind = val.(*VariableBind)
+						bind, ok = val.(*VariableBind)
+						if !ok {
+							logger.Errorw(gocontext.Background(), fmt.Sprintf("Error variables is not of VariableBind type: variables: %+v, current varibale %+v, config filter %+v,", c.variables, c.currentVars, c.Config.filters), "Get", "context")
+							bind = &VariableBind{}
+						}
 						attr, ok := bind.Attributes[strings.TrimPrefix(objArrays[1], ".")]
 						if ok {
 							if attr.Attributes == nil {
@@ -144,7 +148,11 @@ func (c *varsContext) Get(name string) interface{} {
 						}
 						c.variables[loopVar.Source] = bind
 					} else if val != nil {
-						bind = val.(*VariableBind)
+						bind, ok = val.(*VariableBind)
+						if !ok {
+							logger.Errorw(gocontext.Background(), fmt.Sprintf("Error variables is not of VariableBind type: variables: %+v, current varibale %+v, config filter %+v,", c.variables, c.currentVars, c.Config.filters), "Get", "context")
+							bind = &VariableBind{}
+						}
 						bind.Loop = true
 						if bind.Attributes == nil {
 							bind.Attributes = make(map[string]*VariableBind)


### PR DESCRIPTION
It seems one of this kinda super complex loop var email https://ortto.app/droppemarketplace/asset-manager/68535661220f064043d45ac2/email/preview?from=asset-manager-index&key=----------
tricked the bindings into a weird state but I can't locate the issue (fixed in the original asset by the customer)
panic log https://ap3-application-logs.kb.us-east-2.aws.elastic-cloud.com/app/discover#/doc/index-pattern-ap3/.ds-ap3-euprod-k8s-2025.06.18-001866?id=8niJhJcBD-uEbC3s5g9o


add protection and logs